### PR TITLE
Synchronously call EwaldInit() to avoid use-before-init problem.

### DIFF
--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -313,7 +313,6 @@ mainmodule ParallelGravity {
     entry void setPeriodic(int nReplicas, Vector3D<cosmoType> fPeriod, int bEwald,
                            double fEwCut, double fEwhCut, int bPeriod,
                            int bComove, double dRhoFac);
-    entry [notrace] void EwaldInit();
     entry [notrace] void initCoolingData(const CkCallback& cb);
     entry [notrace] void initLWData(const CkCallback& cb);
     entry void calculateEwald(dummyMsg *msg);

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -5271,7 +5271,16 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
 #endif
   traceUserBracketEvent(START_PW, starttime, CmiWallTimer());
 
-  if (bEwald) thisProxy[thisIndex].EwaldInit();
+  if (bEwald) EwaldInit();  // With the GPU consolidation, we lost the
+                            // interlock that ensured that the
+                            // EwaldInit() entry was called before
+                            // evaluating the Ewald forces.
+                            // So now it needs to be called
+                            // synchronously.
+                            // XXX - this is the same on all
+                            // TreePieces, so it should really be done
+                            // in the DataManager, perhaps at the end
+                            // of the tree build stage.
 #if defined CUDA
   // ask datamanager to serialize local trees
   // prefetch can occur concurrently with this, 
@@ -5279,13 +5288,11 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
   // afterwards.
   if (!bUseCpu) {
       dm->serializeLocalTree();
-  } else {
+  } else
+#endif
+  {
       thisProxy[thisIndex].commenceCalculateGravityLocal();
   }
-#else
-  thisProxy[thisIndex].commenceCalculateGravityLocal();
-#endif
-
 
 #ifdef CHANGA_PRINT_MEMUSAGE
       int piecesPerPe = numTreePieces/CmiNumPes();


### PR DESCRIPTION
We need to be sure EwaldInit() is completed before calling CUDA kernels.  Hence we no longer call it as an entry method.