### PR TITLE
Fix SMP memory visibility in remote gravity data transfer gating

### DIFF
--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -54,8 +54,8 @@ void DataManager::init() {
   d_localVars = nullptr;
   d_remoteMoments = nullptr;
   d_remoteParts = nullptr;
-  bLocalDataTransferred = false;
-  bRemoteDataTransferred = false;
+  bLocalDataTransferred.store(false);
+  bRemoteDataTransferred.store(false);
 #endif
   Cool = CoolInit();
   LWData = LymanWernerTableInit();
@@ -660,7 +660,7 @@ void DataManager::finishLocalWalk() {
 /// in one big kernel launch
 void DataManager::startLocalWalk() {
     delete localTransferCallback;
-    bLocalDataTransferred = true;
+    bLocalDataTransferred.store(true);
 
     // We arent calculating local gravity on the CPU, but bookkeeping
     // still needs to be handled
@@ -722,7 +722,7 @@ void DataManager::resumeRemoteChunk() {
   delete currentChunkBuffers->particles;
   delete currentChunkBuffers->cb;
   delete currentChunkBuffers;
-  bRemoteDataTransferred = true;
+  bRemoteDataTransferred.store(true);
 
   // Check and see if the remote walks already finished and are waiting
   // to launch their GPU kernels
@@ -805,6 +805,7 @@ void DataManager::donePrefetch(int chunk){
 				   (void **)&d_remoteMoments,  (void **)&d_remoteParts,
 				   stream,
 				   remoteChunkTransferCallback);
+    bRemoteDataTransferred.store(true);
   }
   CmiUnlock(__nodelock);
 }
@@ -1278,8 +1279,8 @@ void DataManager::updateParticlesFreeMemory(UpdateParticlesStruct *data)
     gpuPoolFree(d_remoteMoments, stream, funcTag);
     gpuPoolFree(d_remoteParts, stream, funcTag);
 
-    bLocalDataTransferred = false;
-    bRemoteDataTransferred = false;
+    bLocalDataTransferred.store(false);
+    bRemoteDataTransferred.store(false);
     // Set device pointers to nullptr
     d_localMoments = nullptr;
     d_localParts = nullptr;

--- a/DataManager.h
+++ b/DataManager.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <map>
+#include <atomic>
 #include <string>
 #include "GenericTreeNode.h"
 #include "ParallelGravity.decl.h"
@@ -94,9 +95,9 @@ protected:
         int treePiecesDonePrefetch;
 public:
         /// Indicates that the local Tree data is on the GPU
-        bool bLocalDataTransferred;
+        std::atomic<bool> bLocalDataTransferred;
         /// Indicates that the remote Tree data is on the GPU
-        bool bRemoteDataTransferred;
+        std::atomic<bool> bRemoteDataTransferred;
 protected:
         /// Counter for PEs that are ready to get their acclerations updated.
         int PEsWantParticlesBack;

--- a/HostCUDA.cu
+++ b/HostCUDA.cu
@@ -550,7 +550,6 @@ void DataTransferBasicCleanup(CudaDevPtr *ptr, cudaStream_t stream, const char* 
  */
 void TransferParticleVarsBack(VariablePartData *hostBuffer, size_t size, void *d_varParts,
                               cudaStream_t stream, void *cb){
-  
   HAPI_TRACE_BEGIN();
   cudaChk(cudaMemcpyAsync(hostBuffer, d_varParts, size, cudaMemcpyDeviceToHost, stream));
   HAPI_TRACE_END(CUDA_XFER_BACK);

--- a/PEList.cpp
+++ b/PEList.cpp
@@ -28,10 +28,13 @@ void PEList::finishWalk(TreePiece *treePiece) {
 
     // If the DataManager device pointer is NULL, the GPU data transfer is
     // still in progress and we need to delay the kernel launch
-    if ((!bRemote && !dMProxy.ckLocalBranch()->bLocalDataTransferred) ||
-        (bRemote && !dMProxy.ckLocalBranch()->bRemoteDataTransferred))
+    bool dataReady = (!bRemote &&
+        dMProxy.ckLocalBranch()->bLocalDataTransferred.load()) ||
+        (bRemote && dMProxy.ckLocalBranch()->bRemoteDataTransferred.load());
+    if (!dataReady)
         bKernelDelayed = 1;
-    else launchKernel();
+    else
+        launchKernel();
 }
 
 /// @brief Called from DataManager after remote transfer finishes. Launch our kernel if it was delayed


### PR DESCRIPTION
Replace plain bool with std::atomic<bool> for bLocalDataTransferred and bRemoteDataTransferred. Prevents deadlock when async callbacks and multiple PEs cause stale reads.