### PR TITLE
Fix startEwaldGPU crash when no TreePiece has valid Ewald data

### DIFF
--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -503,6 +503,32 @@ void DataManager::serializeLocalTree(){
 
 /// @brief Get the data produced by TreePiece::EwaldInit and launch the Ewald kernel on the GPU
 void DataManager::startEwaldGPU() {
+  if (savedNumTotalParticles <= 0 || d_localParts == nullptr || d_localVars == nullptr) {
+    for (int i = 0; i < registeredTreePieces.length(); i++) {
+      int in = registeredTreePieces[i].treePiece->getIndex();
+      treePieces[in].cudaFinishAllBuckets(1);
+    }
+    return;
+  }
+
+  TreePiece *tp = NULL;
+  for (int i = 0; i < registeredTreePieces.length(); i++) {
+    TreePiece *candidate = registeredTreePieces[i].treePiece;
+    if (candidate->root != NULL && candidate->ewt != NULL && candidate->nEwhLoop > 0) {
+      tp = candidate;
+      break;
+    }
+  }
+  if (tp == NULL) {
+    CkAbort("DataManager::startEwaldGPU: no TreePiece with valid Ewald data (root, ewt, nEwhLoop)");
+  }
+
+  int nEwhLoop = tp->nEwhLoop;
+  if (nEwhLoop > NEWH) {
+    CkAbort("DataManager::startEwaldGPU: nEwhLoop (%d) exceeds NEWH (%d); increase NEWH in EwaldCUDA.h",
+            nEwhLoop, NEWH);
+  }
+
 #ifdef PINNED_HOST_MEMORY
   const char* funcTag = "DataManager::startEwaldGPU";
   hostMalloc(&ewt, sizeof(EwtData)*NEWH, funcTag);
@@ -512,11 +538,6 @@ void DataManager::startEwaldGPU() {
   cachedData = (EwaldReadOnlyData *) malloc(sizeof(EwaldReadOnlyData));
 #endif
 
-  // Note that much of this data is calculated per TreePiece. It's all identical,
-  // so we just pull from the first TreePiece
-  TreePiece *tp = registeredTreePieces[0].treePiece;
-
-  int nEwhLoop = tp->nEwhLoop;
   MultipoleMoments *mm = &tp->root->moments;
   for (int i=0; i<nEwhLoop; i++) {
     ewt[i].hx = (cudatype) tp->ewt[i].hx;

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -503,6 +503,9 @@ void DataManager::serializeLocalTree(){
 
 /// @brief Get the data produced by TreePiece::EwaldInit and launch the Ewald kernel on the GPU
 void DataManager::startEwaldGPU() {
+  // Skip GPU Ewald setup when there are no particles or GPU buffers were never
+  // allocated (e.g. no-local-parts run). Still must call cudaFinishAllBuckets
+  // so TreePieces can complete their finishBucket/remote-counter logic.
   if (savedNumTotalParticles <= 0 || d_localParts == nullptr || d_localVars == nullptr) {
     for (int i = 0; i < registeredTreePieces.length(); i++) {
       int in = registeredTreePieces[i].treePiece->getIndex();
@@ -511,6 +514,9 @@ void DataManager::startEwaldGPU() {
     return;
   }
 
+  // Find a TreePiece that ran EwaldInit and has valid Ewald data. Not all TPs
+  // may have it (e.g. empty TPs, or TPs that skipped Ewald). We need one with
+  // root, ewt, and nEwhLoop > 0 to copy data to GPU.
   TreePiece *tp = NULL;
   for (int i = 0; i < registeredTreePieces.length(); i++) {
     TreePiece *candidate = registeredTreePieces[i].treePiece;

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -503,9 +503,13 @@ void DataManager::serializeLocalTree(){
 
 /// @brief Get the data produced by TreePiece::EwaldInit and launch the Ewald kernel on the GPU
 void DataManager::startEwaldGPU() {
-  // Skip GPU Ewald setup when there are no particles or GPU buffers were never
-  // allocated (e.g. no-local-parts run). Still must call cudaFinishAllBuckets
-  // so TreePieces can complete their finishBucket/remote-counter logic.
+  // Early exit when no Ewald work to do: no particles on this node, or GPU
+  // buffers were never allocated (e.g. no-local-parts run).
+  //
+  // We must still call cudaFinishAllBuckets(1) here. Normally that happens in
+  // finishEwaldGPU() (the callback passed to DataManagerEwald). When we skip
+  // the kernel, finishEwaldGPU never runs, so we replicate its behavior here
+  // to avoid deadlock: TPs are waiting for their buckets to be marked finished.
   if (savedNumTotalParticles <= 0 || d_localParts == nullptr || d_localVars == nullptr) {
     for (int i = 0; i < registeredTreePieces.length(); i++) {
       int in = registeredTreePieces[i].treePiece->getIndex();
@@ -514,9 +518,8 @@ void DataManager::startEwaldGPU() {
     return;
   }
 
-  // Find a TreePiece that ran EwaldInit and has valid Ewald data. Not all TPs
-  // may have it (e.g. empty TPs, or TPs that skipped Ewald). We need one with
-  // root, ewt, and nEwhLoop > 0 to copy data to GPU.
+  // Find a TreePiece with valid Ewald data (root, ewt, nEwhLoop from
+  // EwaldInit). registeredTreePieces[0] may be empty or lack Ewald data.
   TreePiece *tp = NULL;
   for (int i = 0; i < registeredTreePieces.length(); i++) {
     TreePiece *candidate = registeredTreePieces[i].treePiece;

--- a/EwaldCUDA.h
+++ b/EwaldCUDA.h
@@ -3,7 +3,7 @@
 
 #include "HostCUDA.h"
 
-#define NEWH 80
+#define NEWH 400
 #define BLOCK_SIZE 128
 
 /** @brief Data for the Ewald h loop in the CUDA kernel


### PR DESCRIPTION
Search for first TP with valid root/ewt/nEwhLoop instead of using registeredTreePieces[0] blindly. Add nEwhLoop <= NEWH check. Increase NEWH to 400.