### PR TITLE
Allocate particleInterRemote before finishWalk to avoid NULL dereference in callbacks

### DIFF
--- a/Compute.cpp
+++ b/Compute.cpp
@@ -310,6 +310,10 @@ void GravityCompute::recvdParticles(ExternalGravityParticle *part,int num,int ch
 #ifdef BENCHMARK_TIME_COMPUTE
   computeTimePart += CmiWallTimer() - startTime;
 #endif
+  if (tp->particleInterRemote == NULL) {
+    CkPrintf("ERROR [%d] TP %d particleInterRemote NULL at chunk %d (GravityCompute::recvdParticles)\n", CkMyPe(), tp->getIndex(), chunk);
+    CkAbort("particleInterRemote NULL");
+  }
   tp->particleInterRemote[chunk] += computed * num;
   tp->finishBucket(reqIDlist);
   CkAssert(state->counterArrays[1][chunk] >= 0);
@@ -345,6 +349,10 @@ void GravityCompute::nodeRecvdEvent(TreePiece *owner, int chunk, State *state, i
   state->counterArrays[1][chunk] --;
   CkAssert(state->counterArrays[1][chunk] >= 0);
   if (state->counterArrays[1][chunk] == 0) {
+    if (owner->particleInterRemote == NULL) {
+      CkPrintf("ERROR [%d] TP %d particleInterRemote NULL at chunk %d (GravityCompute::nodeRecvdEvent)\n", CkMyPe(), owner->getIndex(), chunk);
+      CkAbort("particleInterRemote NULL");
+    }
     cacheGravPart[CkMyPe()].finishedChunk(chunk, owner->particleInterRemote[chunk]);
 #ifdef CHECK_WALK_COMPLETIONS
     CkPrintf("[%d] finishedChunk %d GravityCompute::nodeRecvdEvent\n", owner->getIndex(), chunk);
@@ -395,6 +403,10 @@ void ListCompute::nodeRecvdEvent(TreePiece *owner, int chunk, State *state, int 
 #if COSMO_PRINT_BK > 1
     CkPrintf("[%d] FINISHED CHUNK %d from nodeRecvdEvent\n", owner->getIndex(), chunk);
 #endif
+    if (owner->particleInterRemote == NULL) {
+      CkPrintf("ERROR [%d] TP %d particleInterRemote NULL at chunk %d (ListCompute::nodeRecvdEvent)\n", CkMyPe(), owner->getIndex(), chunk);
+      CkAbort("particleInterRemote NULL");
+    }
     cacheGravPart[CkMyPe()].finishedChunk(chunk, owner->particleInterRemote[chunk]);
 #ifdef CHECK_WALK_COMPLETIONS
     CkPrintf("[%d] finishedChunk %d ListCompute::nodeRecvdEvent\n", owner->getIndex(), chunk);
@@ -965,6 +977,10 @@ void ListCompute::recvdParticles(ExternalGravityParticle *part,int num,int chunk
 #if COSMO_PRINT_BK > 1
     CkPrintf("[%d] FINISHED CHUNK %d from recvdParticles\n", tp->getIndex(), chunk);
 #endif
+    if (tp->particleInterRemote == NULL) {
+      CkPrintf("ERROR [%d] TP %d particleInterRemote NULL at chunk %d (ListCompute::recvdParticles)\n", CkMyPe(), tp->getIndex(), chunk);
+      CkAbort("particleInterRemote NULL");
+    }
     cacheGravPart[CkMyPe()].finishedChunk(chunk, tp->particleInterRemote[chunk]);
 #ifdef CHECK_WALK_COMPLETIONS
     CkPrintf("[%d] finishedChunk %d ListCompute::recvdParticles\n", tp->getIndex(), chunk);

--- a/Compute.cpp
+++ b/Compute.cpp
@@ -310,10 +310,7 @@ void GravityCompute::recvdParticles(ExternalGravityParticle *part,int num,int ch
 #ifdef BENCHMARK_TIME_COMPUTE
   computeTimePart += CmiWallTimer() - startTime;
 #endif
-  if (tp->particleInterRemote == NULL) {
-    CkPrintf("ERROR [%d] TP %d particleInterRemote NULL at chunk %d (GravityCompute::recvdParticles)\n", CkMyPe(), tp->getIndex(), chunk);
-    CkAbort("particleInterRemote NULL");
-  }
+  CkAssert(tp->particleInterRemote != NULL);
   tp->particleInterRemote[chunk] += computed * num;
   tp->finishBucket(reqIDlist);
   CkAssert(state->counterArrays[1][chunk] >= 0);
@@ -349,10 +346,7 @@ void GravityCompute::nodeRecvdEvent(TreePiece *owner, int chunk, State *state, i
   state->counterArrays[1][chunk] --;
   CkAssert(state->counterArrays[1][chunk] >= 0);
   if (state->counterArrays[1][chunk] == 0) {
-    if (owner->particleInterRemote == NULL) {
-      CkPrintf("ERROR [%d] TP %d particleInterRemote NULL at chunk %d (GravityCompute::nodeRecvdEvent)\n", CkMyPe(), owner->getIndex(), chunk);
-      CkAbort("particleInterRemote NULL");
-    }
+    CkAssert(owner->particleInterRemote != NULL);
     cacheGravPart[CkMyPe()].finishedChunk(chunk, owner->particleInterRemote[chunk]);
 #ifdef CHECK_WALK_COMPLETIONS
     CkPrintf("[%d] finishedChunk %d GravityCompute::nodeRecvdEvent\n", owner->getIndex(), chunk);

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -4574,6 +4574,10 @@ void TreePiece::calculateGravityRemote(ComputeChunkMsg *msg) {
       }
 #endif
 
+      if (particleInterRemote == NULL) {
+        CkPrintf("ERROR [%d] TP %d particleInterRemote NULL at chunk %d (calculateGravityRemote)\n", CkMyPe(), thisIndex, msg->chunkNum);
+        CkAbort("particleInterRemote NULL");
+      }
       cacheGravPart[CkMyPe()].finishedChunk(msg->chunkNum, particleInterRemote[msg->chunkNum]);
 #ifdef CHECK_WALK_COMPLETIONS
       CkPrintf("[%d] finishedChunk TreePiece::calculateGravityRemote\n", thisIndex);
@@ -5022,6 +5026,25 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
   if (numChunks == 0 && myNumParticles == 0) numChunks = 1;
   int dummy;
 
+  // Allocate particleInterRemote/nodeInterRemote early so they are valid if
+  // callbacks arrive (e.g. after migration or from stale cache). PUP sets
+  // these to NULL on unpack; allocation must happen before any cache/Compute
+  // path can touch them.
+  if (oldNumChunks != numChunks) {
+    delete[] nodeInterRemote;
+    delete[] particleInterRemote;
+    nodeInterRemote = new u_int64_t[numChunks];
+    particleInterRemote = new u_int64_t[numChunks];
+  }
+  if (nodeInterRemote == NULL)
+    nodeInterRemote = new u_int64_t[numChunks];
+  if (particleInterRemote == NULL)
+    particleInterRemote = new u_int64_t[numChunks];
+  for (int i = 0; i < numChunks; ++i) {
+    nodeInterRemote[i] = 0;
+    particleInterRemote[i] = 0;
+  }
+
   cacheNode.ckLocalBranch()->cacheSync(numChunks, idxMax, localIndex);
   cacheGravPart.ckLocalBranch()->cacheSync(numChunks, idxMax, dummy);
 
@@ -5049,29 +5072,13 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
     bBucketsInited = true;
     return;
   }
-  
-  // allocate and zero out statistics counters
-  if (oldNumChunks != numChunks ) {
-    delete[] nodeInterRemote;
-    delete[] particleInterRemote;
-    nodeInterRemote = new u_int64_t[numChunks];
-    particleInterRemote = new u_int64_t[numChunks];
-  }
 
-  if(nodeInterRemote == NULL)
-	nodeInterRemote = new u_int64_t[numChunks];
-  if(particleInterRemote == NULL)
-	particleInterRemote = new u_int64_t[numChunks];
 #if COSMO_STATS > 0
   nodesOpenedLocal = 0;
   nodesOpenedRemote = 0;
   numOpenCriterionCalls=0;
 #endif
   nodeInterLocal = 0;
-  for (int i=0; i<numChunks; ++i) {
-    nodeInterRemote[i] = 0;
-    particleInterRemote[i] = 0;
-  }
   particleInterLocal = 0;
 
   if(verbosity>1)

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -5026,10 +5026,10 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
   if (numChunks == 0 && myNumParticles == 0) numChunks = 1;
   int dummy;
 
-  // Allocate particleInterRemote/nodeInterRemote early so they are valid if
-  // callbacks arrive (e.g. after migration or from stale cache). PUP sets
-  // these to NULL on unpack; allocation must happen before any cache/Compute
-  // path can touch them.
+  // Allocate particleInterRemote/nodeInterRemote before PEList::finishWalk()
+  // is invoked (e.g. in the myNumParticles==0 path via finishedTPWork).
+  // They must be valid if any callback arrives. PUP sets them to NULL on
+  // unpack; allocation must happen before any cache/Compute path can touch them.
   if (oldNumChunks != numChunks) {
     delete[] nodeInterRemote;
     delete[] particleInterRemote;


### PR DESCRIPTION
Move allocation before myNumParticles==0 early return. Add defensive NULL checks in Compute paths (recvdParticles, nodeRecvdEvent).