### PR TITLE
Fix gravity/smooth particle cache pointer-smuggling and fcnSmooth use-after-free

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ cuda.mk
 
 # Dependency files
 *.d
+
+# Build output
+metal/
+
+# Run logs and analysis (move key .md to repo root if needed)
+logs/

--- a/CacheInterface.cpp
+++ b/CacheInterface.cpp
@@ -59,13 +59,23 @@ int EntryTypeGravityParticle::size(void * data) {
 /// @param chunk Which chunk is this for.
 void EntryTypeGravityParticle::callback(CkArrayID requestorID, CkArrayIndexMax &requestorIdx, KeyType key, CkCacheUserData &userData, void *data, int chunk) {
   CkArrayIndex1D idx(requestorIdx.data()[0]);
-  CProxyElement_TreePiece elem(requestorID, idx);
   CacheParticle *cp = (CacheParticle *)data;
   int reqID = (int)(userData.d0 & 0xFFFFFFFF);
   int awi = userData.d0 >> 32;
-  void *source = (void *)userData.d1;
+  int num = cp->end - cp->begin + 1;
 
-  elem.receiveParticlesCallback(cp->part, cp->end - cp->begin + 1, chunk, reqID, key, awi, source);
+  // Always serialize and send via receiveParticlesCallbackFromRemote. Never pass raw pointers
+  // (cp->part, source) across PEs -- same pointer-smuggling fix as node cache.
+  RecvParticlesCallbackMsg *msg = new (num, 0) RecvParticlesCallbackMsg();
+  msg->chunk = chunk;
+  msg->reqID = reqID;
+  msg->awi = awi;
+  msg->key = key;
+  msg->num = num;
+  for (int i = 0; i < num; i++) {
+    msg->particles[i] = cp->part[i];
+  }
+  treeProxy[requestorIdx.data()[0]].receiveParticlesCallbackFromRemote(msg);
 }
 
 
@@ -179,16 +189,31 @@ int EntryTypeSmoothParticle::size(void * data) {
 }
 
 void EntryTypeSmoothParticle::callback(CkArrayID requestorID, CkArrayIndexMax &requestorIdx, KeyType key, CkCacheUserData &userData, void *data, int chunk) {
-  CkArrayIndex1D idx(requestorIdx.data()[0]);
-  CProxyElement_TreePiece elem(requestorID, idx);
+  CacheSmoothParticle *cPart = (CacheSmoothParticle *)data;
   int reqID = (int)(userData.d0 & 0xFFFFFFFF);
   int awi = userData.d0 >> 32;
-  void *source = (void *)userData.d1;
-  CacheSmoothParticle *cPart = (CacheSmoothParticle *)data;
 
-  elem.receiveParticlesFullCallback(cPart->partCached,
-				cPart->end - cPart->begin + 1, chunk, reqID,
-				key, awi, source);
+  // Always serialize and send via receiveParticlesFullCallbackFromRemote. Never pass raw pointers
+  // (cPart->partCached, source) across PEs -- same pointer-smuggling fix as gravity particle cache.
+  int nActual = cPart->nActual;
+  RecvParticlesFullCallbackMsg *msg = new (nActual, 0) RecvParticlesFullCallbackMsg();
+  msg->chunk = chunk;
+  msg->reqID = reqID;
+  msg->awi = awi;
+  msg->key = key;
+  msg->begin = cPart->begin;
+  msg->end = cPart->end;
+  msg->nActual = nActual;
+  int j = 0;
+  for (int i = 0; i < 1 + cPart->end - cPart->begin; ++i) {
+    if (cPart->partCached[i].iType != 0) {
+      msg->partExt[j] = cPart->partCached[i].getExternalSmoothParticle();
+      msg->partExt[j].iBucketOff = i;
+      j++;
+    }
+  }
+  CkAssert(j == nActual);
+  treeProxy[requestorIdx.data()[0]].receiveParticlesFullCallbackFromRemote(msg);
 }
 
 // satisfy buffered requests
@@ -432,35 +457,25 @@ void EntryTypeGravityNode::callback(CkArrayID requestorID, CkArrayIndexMax &requ
              CkMyPe(), (int)requestorIdx.data()[0], chunk);
     CkAbort("EntryTypeGravityNode::callback NULL data");
   }
-  CProxy_TreePiece requestorProxy(requestorID);
   CkArrayIndex1D idx(requestorIdx.data()[0]);
-  int requestorPe = requestorProxy.ckLocMgr()->whichPe(idx);
-  if (requestorPe < 0) {
-    CkPrintf("ERROR [%d] EntryTypeGravityNode::callback cannot determine PE for requestor %d\n",
-             CkMyPe(), (int)requestorIdx.data()[0]);
-    CkAbort("EntryTypeGravityNode::callback whichPe failed");
-  }
   int reqID = (int)(userData.d0 & 0xFFFFFFFF);
   int awi = userData.d0 >> 32;
 
-  if (requestorPe != CkMyPe()) {
-    // Cross-PE: requestor migrated since request. Serialize node and send.
-    Tree::BinaryTreeNode *node = (Tree::BinaryTreeNode *)data;
-    int count = node->countDepth(_cacheLineDepth);
-    size_t nodeDataSize = PAD_reply + count * ALIGN_DEFAULT(sizeof(Tree::BinaryTreeNode) + PAD_reply);
-    RecvNodeCallbackMsg *fwd = new (nodeDataSize) RecvNodeCallbackMsg();
-    fwd->chunk = chunk;
-    fwd->reqID = reqID;
-    fwd->awi = awi;
-    fwd->key = key;
-    Tree::BinaryTreeNode *dst = (Tree::BinaryTreeNode *)(fwd->nodeData + PAD_reply);
-    node->packNodes(dst, _cacheLineDepth, PAD_reply);
-    treeProxy[requestorIdx.data()[0]].receiveNodeCallbackFromRemote(fwd);
-    return;
-  }
-  CProxyElement_TreePiece elem(requestorID, idx);
-  void *source = (void *)userData.d1;
-  elem.receiveNodeCallback((Tree::GenericTreeNode*)data, chunk, reqID, awi, source);
+  // Always serialize and send via receiveNodeCallbackFromRemote. Never pass raw pointers
+  // (node, source) across PEs -- they are only valid on this PE. The [local] entry
+  // receiveNodeCallback cannot safely receive them when invoked remotely; and whichPe
+  // could be stale or wrong. Serializing guarantees the TreePiece gets valid local data.
+  Tree::BinaryTreeNode *node = (Tree::BinaryTreeNode *)data;
+  int count = node->countDepth(_cacheLineDepth);
+  size_t nodeDataSize = PAD_reply + count * ALIGN_DEFAULT(sizeof(Tree::BinaryTreeNode) + PAD_reply);
+  RecvNodeCallbackMsg *fwd = new (nodeDataSize) RecvNodeCallbackMsg();
+  fwd->chunk = chunk;
+  fwd->reqID = reqID;
+  fwd->awi = awi;
+  fwd->key = key;
+  Tree::BinaryTreeNode *dst = (Tree::BinaryTreeNode *)(fwd->nodeData + PAD_reply);
+  node->packNodes(dst, _cacheLineDepth, PAD_reply);
+  treeProxy[requestorIdx.data()[0]].receiveNodeCallbackFromRemote(fwd);
 }
 
 

--- a/CacheInterface.cpp
+++ b/CacheInterface.cpp
@@ -2,15 +2,14 @@
 ///
 /// Implementation of the interfaces used by the CacheManager.
 ///
+#include <cstdio>
+#include <cstdlib>
 #include "CacheInterface.h"
 #include "ParallelGravity.h"
 #include "Opt.h"
 #include "smooth.h"
 #include "Compute.h"
 #include "TreeWalk.h"
-
-static const int PAD_reply = sizeof(NodeKey);  // Assume this is bigger
-                                           // than a pointer
 
 EntryTypeGravityParticle::EntryTypeGravityParticle() {
   CkCacheFillMsg<KeyType> msg(0);
@@ -428,10 +427,38 @@ int EntryTypeGravityNode::size(void * data) {
 }
 
 void EntryTypeGravityNode::callback(CkArrayID requestorID, CkArrayIndexMax &requestorIdx, KeyType key, CkCacheUserData &userData, void *data, int chunk) {
+  if (data == NULL) {
+    CkPrintf("ERROR [%d] EntryTypeGravityNode::callback received NULL data (requestor %d, chunk %d)\n",
+             CkMyPe(), (int)requestorIdx.data()[0], chunk);
+    CkAbort("EntryTypeGravityNode::callback NULL data");
+  }
+  CProxy_TreePiece requestorProxy(requestorID);
   CkArrayIndex1D idx(requestorIdx.data()[0]);
-  CProxyElement_TreePiece elem(requestorID, idx);
+  int requestorPe = requestorProxy.ckLocMgr()->whichPe(idx);
+  if (requestorPe < 0) {
+    CkPrintf("ERROR [%d] EntryTypeGravityNode::callback cannot determine PE for requestor %d\n",
+             CkMyPe(), (int)requestorIdx.data()[0]);
+    CkAbort("EntryTypeGravityNode::callback whichPe failed");
+  }
   int reqID = (int)(userData.d0 & 0xFFFFFFFF);
   int awi = userData.d0 >> 32;
+
+  if (requestorPe != CkMyPe()) {
+    // Cross-PE: requestor migrated since request. Serialize node and send.
+    Tree::BinaryTreeNode *node = (Tree::BinaryTreeNode *)data;
+    int count = node->countDepth(_cacheLineDepth);
+    size_t nodeDataSize = PAD_reply + count * ALIGN_DEFAULT(sizeof(Tree::BinaryTreeNode) + PAD_reply);
+    RecvNodeCallbackMsg *fwd = new (nodeDataSize) RecvNodeCallbackMsg();
+    fwd->chunk = chunk;
+    fwd->reqID = reqID;
+    fwd->awi = awi;
+    fwd->key = key;
+    Tree::BinaryTreeNode *dst = (Tree::BinaryTreeNode *)(fwd->nodeData + PAD_reply);
+    node->packNodes(dst, _cacheLineDepth, PAD_reply);
+    treeProxy[requestorIdx.data()[0]].receiveNodeCallbackFromRemote(fwd);
+    return;
+  }
+  CProxyElement_TreePiece elem(requestorID, idx);
   void *source = (void *)userData.d1;
   elem.receiveNodeCallback((Tree::GenericTreeNode*)data, chunk, reqID, awi, source);
 }

--- a/CacheInterface.h
+++ b/CacheInterface.h
@@ -13,7 +13,7 @@
 #include "GenericTreeNode.h"
 #include "keytype.h"
 
-static const int PAD_reply = sizeof(NodeKey);
+static const int PAD_reply = sizeof(Tree::NodeKey);
 
 /*********************************************************
  * Gravity interface: Particles

--- a/CacheInterface.h
+++ b/CacheInterface.h
@@ -13,6 +13,8 @@
 #include "GenericTreeNode.h"
 #include "keytype.h"
 
+static const int PAD_reply = sizeof(NodeKey);
+
 /*********************************************************
  * Gravity interface: Particles
  *********************************************************/

--- a/Compute.h
+++ b/Compute.h
@@ -80,7 +80,8 @@ class Compute{
   /// Allow book-keeping of a cache receive event.
   virtual void recvdParticles(ExternalGravityParticle *egp,int num,int chunk,int reqID,State *state, TreePiece *tp, Tree::NodeKey &remoteBucket){}
   /// Allow book-keeping of a cache receive event.
-  virtual void recvdParticlesFull(GravityParticle *egp,int num,int chunk,int reqID,State *state, TreePiece *tp, Tree::NodeKey &remoteBucket){}
+  /// allocPart/allocExtra: when non-NULL, deferred-freed after walkDone (smooth cache).
+  virtual void recvdParticlesFull(GravityParticle *egp,int num,int chunk,int reqID,State *state, TreePiece *tp, Tree::NodeKey &remoteBucket, GravityParticle *allocPart=0, extraSPHData *allocExtra=0){}
   virtual ~Compute(){}
   virtual void walkDone(State *state){}
   virtual void setComputeEntity(void *ce){

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -94,6 +94,13 @@ mainmodule ParallelGravity {
 
   message dummyMsg;
   message ComputeChunkMsg;
+  message RecvNodeCallbackMsg {
+    int chunk;
+    int reqID;
+    int awi;
+    KeyType key;
+    char nodeData[];
+  };
 
 #ifdef CUDA
   message fillGPUMsg{
@@ -513,6 +520,7 @@ mainmodule ParallelGravity {
 
     entry [expedited] void fillRequestNode(CkCacheRequestMsg<KeyType> *msg);
     entry [local] void receiveNodeCallback(GenericTreeNode *node, int chunk, int reqID, int awi, void *source);
+    entry void receiveNodeCallbackFromRemote(RecvNodeCallbackMsg *msg);
     //entry void receiveNode(GenericTreeNode node[1],
     //	       unsigned int reqID);
     //entry void receiveParticle(GravityParticle part,

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -102,6 +102,26 @@ mainmodule ParallelGravity {
     char nodeData[];
   };
 
+  message RecvParticlesCallbackMsg {
+    int chunk;
+    int reqID;
+    int awi;
+    KeyType key;
+    int num;
+    ExternalGravityParticle particles[];
+  };
+
+  message RecvParticlesFullCallbackMsg {
+    int chunk;
+    int reqID;
+    int awi;
+    KeyType key;
+    int begin;
+    int end;
+    int nActual;
+    ExternalSmoothParticle partExt[];
+  };
+
 #ifdef CUDA
   message fillGPUMsg{
     int partIndex;
@@ -529,6 +549,8 @@ mainmodule ParallelGravity {
     entry [expedited] void fillRequestSmoothParticles(CkCacheRequestMsg<KeyType> *msg);
     entry void flushSmoothParticles(CkCacheFillMsg<KeyType> *msg);
     entry [local] void receiveParticlesCallback(ExternalGravityParticle *egp, int num, int chunk, int reqID, Tree::NodeKey &remoteBucket, int awi, void *source);
+    entry void receiveParticlesCallbackFromRemote(RecvParticlesCallbackMsg *msg);
+    entry void receiveParticlesFullCallbackFromRemote(RecvParticlesFullCallbackMsg *msg);
     entry [local] void receiveParticlesFullCallback(GravityParticle *egp, int num, int chunk, int reqID, Tree::NodeKey &remoteBucket, int awi, void *source);
 
     // jetley

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -343,6 +343,9 @@ struct BucketMsg : public CkMcastBaseMsg, public CMessage_BucketMsg {
 };
 #endif
 
+/// Message for cross-PE node callback (TreePiece migrated after cache request)
+typedef CMessage_RecvNodeCallbackMsg RecvNodeCallbackMsg;
+
 #ifdef CUDA
 struct fillGPUMsg: public CMessage_fillGPUMsg {
   int partIndex;
@@ -1958,6 +1961,7 @@ public:
 	    }
 
         void receiveNodeCallback(GenericTreeNode *node, int chunk, int reqID, int awi, void *source);
+        void receiveNodeCallbackFromRemote(RecvNodeCallbackMsg *msg);
         void receiveParticlesCallback(ExternalGravityParticle *egp, int num, int chunk, int reqID, Tree::NodeKey &remoteBucket, int awi, void *source);
         void receiveParticlesFullCallback(GravityParticle *egp, int num, int chunk, int reqID, Tree::NodeKey &remoteBucket, int awi, void *source);
 
@@ -1969,12 +1973,12 @@ public:
         void sendRequestForNonLocalMoments(GenericTreeNode *pickedNode);
         void mergeNonLocalRequestsDone();
         //void addTreeBuildMomentsClient(GenericTreeNode *targetNode, TreePiece *client, GenericTreeNode *clientNode);
-        std::map<NodeKey,NonLocalMomentsClientList>::iterator createTreeBuildMomentsEntry(GenericTreeNode *pickedNode);
+        std::map<Tree::NodeKey,NonLocalMomentsClientList>::iterator createTreeBuildMomentsEntry(GenericTreeNode *pickedNode);
 
 
         private:
         // XXX - hashtable instead of map
-        std::map<NodeKey,NonLocalMomentsClientList> nonLocalMomentsClients;
+        std::map<Tree::NodeKey,NonLocalMomentsClientList> nonLocalMomentsClients;
         bool localTreeBuildComplete;
         int getResponsibleIndex(int first, int last);
         
@@ -1983,7 +1987,7 @@ public:
         void accumulateMomentsFromChild(GenericTreeNode *parent, GenericTreeNode *child);
 
         void deliverMomentsToClients(GenericTreeNode *);
-        void deliverMomentsToClients(const std::map<NodeKey,NonLocalMomentsClientList>::iterator &it);
+        void deliverMomentsToClients(const std::map<Tree::NodeKey,NonLocalMomentsClientList>::iterator &it);
         void treeBuildComplete();
         void processRemoteRequestsForMoments();
         void sendParticlesDuringDD(bool withqd);

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -346,6 +346,32 @@ struct BucketMsg : public CkMcastBaseMsg, public CMessage_BucketMsg {
 /// Message for cross-PE node callback (TreePiece migrated after cache request)
 typedef CMessage_RecvNodeCallbackMsg RecvNodeCallbackMsg;
 
+/// Message for cross-PE particle callback (same pointer-smuggling fix as node cache)
+class RecvParticlesCallbackMsg : public CMessage_RecvParticlesCallbackMsg {
+public:
+  int chunk;
+  int reqID;
+  int awi;
+  KeyType key;
+  int num;
+  ExternalGravityParticle *particles;
+  RecvParticlesCallbackMsg() {}
+};
+
+/// Message for cross-PE smooth particle full callback (same pointer-smuggling fix)
+class RecvParticlesFullCallbackMsg : public CMessage_RecvParticlesFullCallbackMsg {
+public:
+  int chunk;
+  int reqID;
+  int awi;
+  KeyType key;
+  int begin;
+  int end;
+  int nActual;
+  ExternalSmoothParticle *partExt;
+  RecvParticlesFullCallbackMsg() {}
+};
+
 #ifdef CUDA
 struct fillGPUMsg: public CMessage_fillGPUMsg {
   int partIndex;
@@ -819,6 +845,9 @@ class TreePiece : public CBase_TreePiece {
    int nCacheAccesses; // keep track of outstanding cache accesses to
 		       // know when writebacks complete.  XXX this
 		       // should be part of the smooth state
+   /// Allocations from receiveParticlesFullCallbackFromRemote; recvdParticlesFull registers for deferred free.
+   GravityParticle *pendingRecvdPartAlloc;
+   extraSPHData *pendingRecvdExtraAlloc;
    
    /// number of active particles on the last active rung for load balancing
    unsigned int nPrevActiveParts;
@@ -1411,6 +1440,8 @@ public:
 	  pTreeNodes = NULL;
 	  bucketReqs=NULL;
 	  nCacheAccesses = 0;
+	  pendingRecvdPartAlloc = NULL;
+	  pendingRecvdExtraAlloc = NULL;
 	  memWithCache = 0;
 	  memPostCache = 0;
 	  nNodeCacheEntries = 0;
@@ -1488,6 +1519,8 @@ public:
 	  bucketReqs = NULL;
 	  numChunks=-1;
 	  nCacheAccesses = 0;
+	  pendingRecvdPartAlloc = NULL;
+	  pendingRecvdExtraAlloc = NULL;
 	  memWithCache = 0;
 	  memPostCache = 0;
 	  nNodeCacheEntries = 0;
@@ -1963,6 +1996,8 @@ public:
         void receiveNodeCallback(GenericTreeNode *node, int chunk, int reqID, int awi, void *source);
         void receiveNodeCallbackFromRemote(RecvNodeCallbackMsg *msg);
         void receiveParticlesCallback(ExternalGravityParticle *egp, int num, int chunk, int reqID, Tree::NodeKey &remoteBucket, int awi, void *source);
+        void receiveParticlesCallbackFromRemote(RecvParticlesCallbackMsg *msg);
+        void receiveParticlesFullCallbackFromRemote(RecvParticlesFullCallbackMsg *msg);
         void receiveParticlesFullCallback(GravityParticle *egp, int num, int chunk, int reqID, Tree::NodeKey &remoteBucket, int awi, void *source);
 
         void balanceBeforeInitialForces(const CkCallback &cb);

--- a/State.h
+++ b/State.h
@@ -165,8 +165,8 @@ class DoubleWalkState : public State {
 
   /// Map of node to index in node vector being sent to the GPU. This is
   /// used for remote nodes.
-  std::unordered_map<NodeKey,int> nodeMap;
-  std::unordered_map<NodeKey,int> partMap;
+  std::unordered_map<Tree::NodeKey,int> nodeMap;
+  std::unordered_map<Tree::NodeKey,int> partMap;
 
   // TODO do these need to be shut off (no restriction)?
   // The PELists still need to collect the entire interaction list in memory

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -6207,6 +6207,14 @@ void TreePiece::receiveNodeCallback(GenericTreeNode *node, int chunk, int reqID,
   compute->nodeRecvdEvent(this,chunk,state,targetBucket);
 }
 
+void TreePiece::receiveNodeCallbackFromRemote(RecvNodeCallbackMsg *msg) {
+  Tree::BinaryTreeNode *node = (Tree::BinaryTreeNode *)(msg->nodeData + PAD_reply);
+  node->unpackNodes();
+  void *source = (void *)bucketList[decodeReqID(msg->reqID)];
+  receiveNodeCallback(node, msg->chunk, msg->reqID, msg->awi, source);
+  CkFreeMsg(msg);
+}
+
 void TreePiece::receiveParticlesCallback(ExternalGravityParticle *egp, int num, int chunk, int reqID, Tree::NodeKey &remoteBucket, int awi, void *source){
   Compute *c;
   State *state;

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -6168,6 +6168,15 @@ checkWalkCorrectness();
 void TreePiece::receiveNodeCallback(GenericTreeNode *node, int chunk, int reqID, int awi, void *source){
   int targetBucket = decodeReqID(reqID);
 
+  // source from userData.d1 can be a dangling pointer if callback runs on wrong PE
+  // (cache delivers before cross-PE forward). Always use bucketList for valid local ref.
+  if (targetBucket < 0 || targetBucket >= numBuckets) {
+    CkPrintf("ERROR [%d] TP %d receiveNodeCallback targetBucket=%d out of range [0,%d)\n",
+             CkMyPe(), thisIndex, targetBucket, numBuckets);
+    CkAbort("receiveNodeCallback invalid targetBucket");
+  }
+  void *sourceSafe = (void *)bucketList[targetBucket];
+
   TreeWalk *tw;
   Compute *compute;
   State *state;
@@ -6192,18 +6201,16 @@ void TreePiece::receiveNodeCallback(GenericTreeNode *node, int chunk, int reqID,
   compute = a.c;
   state = a.s;
 
-  // reassociate objects with each other
+  if (tw == NULL || compute == NULL || state == NULL) {
+    CkPrintf("ERROR [%d] TP %d receiveNodeCallback activeWalk[%d] has NULL tw=%p c=%p s=%p\n",
+             CkMyPe(), thisIndex, awi, (void*)tw, (void*)compute, (void*)state);
+    CkAbort("receiveNodeCallback invalid activeWalk (migration?)");
+  }
+
+  void *sourceSafe = (void *)bucketList[decodeReqID(reqID)];
   tw->reassoc(compute);
-  compute->reassoc(source, activeRung, a.o);
-
-  // resume walk
+  compute->reassoc(sourceSafe, activeRung, a.o);
   tw->resumeWalk(node, state, chunk, reqID, awi);
-
-  // we need source to update the counters in all buckets
-  // underneath the source. note that in the interlist walk,
-  // the computeEntity of the compute will likely  have changed as the walk continued.
-  // however, the resumeWalk function takes care to set it back to 'source'
-  // after it is done walking.
   compute->nodeRecvdEvent(this,chunk,state,targetBucket);
 }
 
@@ -6212,6 +6219,41 @@ void TreePiece::receiveNodeCallbackFromRemote(RecvNodeCallbackMsg *msg) {
   node->unpackNodes();
   void *source = (void *)bucketList[decodeReqID(msg->reqID)];
   receiveNodeCallback(node, msg->chunk, msg->reqID, msg->awi, source);
+  CkFreeMsg(msg);
+}
+
+void TreePiece::receiveParticlesCallbackFromRemote(RecvParticlesCallbackMsg *msg) {
+  void *sourceSafe = (void *)bucketList[decodeReqID(msg->reqID)];
+  Tree::NodeKey remoteBucket = msg->key;
+  receiveParticlesCallback(msg->particles, msg->num, msg->chunk, msg->reqID, remoteBucket, msg->awi, sourceSafe);
+  CkFreeMsg(msg);
+}
+
+void TreePiece::receiveParticlesFullCallbackFromRemote(RecvParticlesFullCallbackMsg *msg) {
+  void *sourceSafe = (void *)bucketList[decodeReqID(msg->reqID)];
+  Tree::NodeKey remoteBucket = msg->key;
+  int nTotal = 1 + msg->end - msg->begin;
+  GravityParticle *partCached = new GravityParticle[nTotal];
+  CkAssert(sizeof(extraSPHData) > sizeof(extraStarData));
+  extraSPHData *extraSPHCached = new extraSPHData[msg->nActual];
+  int j = 0;
+  for (int i = 0; i < nTotal; i++) {
+    if (j < msg->nActual && i == msg->partExt[j].iBucketOff) {
+      partCached[i].extraData = &extraSPHCached[j];
+      msg->partExt[j].getParticle(&partCached[i]);
+      CkAssert(TYPETest(&partCached[i], globalSmoothParams->iType));
+      globalSmoothParams->initSmoothCache(&partCached[i]);
+      j++;
+    } else {
+      partCached[i].iType = 0;
+    }
+  }
+  CkAssert(j == msg->nActual);
+  pendingRecvdPartAlloc = partCached;
+  pendingRecvdExtraAlloc = extraSPHCached;
+  receiveParticlesFullCallback(partCached, nTotal, msg->chunk, msg->reqID, remoteBucket, msg->awi, sourceSafe);
+  pendingRecvdPartAlloc = NULL;
+  pendingRecvdExtraAlloc = NULL;
   CkFreeMsg(msg);
 }
 
@@ -6279,7 +6321,7 @@ void TreePiece::receiveParticlesFullCallback(GravityParticle *gp, int num,
   state = a.s;
 
   c->reassoc(source, activeRung, a.o);
-  c->recvdParticlesFull(gp,num,chunk,reqID,state,this, remoteBucket);
+  c->recvdParticlesFull(gp,num,chunk,reqID,state,this, remoteBucket, pendingRecvdPartAlloc, pendingRecvdExtraAlloc);
 }
 
 void TreePiece::addActiveWalk(int iAwi, TreeWalk *tw, Compute *c, Opt *o,

--- a/smooth.cpp
+++ b/smooth.cpp
@@ -149,12 +149,18 @@ void SmoothCompute::nodeMissedEvent(int reqID, int chunk, State *state, TreePiec
     state->counterArrays[0][reqIDlist]++;
     }
 
+void NearNeighborState::initPendingFrees(int nBuckets) {
+  nPendingFreesBuckets = nBuckets;
+  pendingFrees = new CkVec<RecvdSmoothPartAlloc>[nBuckets];
+}
+
 // called after constructor, so tp should be set
 State *KNearestSmoothCompute::getNewState(int nBuckets){
   NearNeighborState *state = new NearNeighborState(tp->myNumParticles+2, nSmooth);
   // array to keep track of outstanding requests
   state->counterArrays[0] = new int [nBuckets];
   state->counterArrays[1] = 0;
+  state->initPendingFrees(nBuckets);
 
   for(int j = 0; j < nBuckets; ++j){
     state->counterArrays[0][j] = 1;	// so we know that the local
@@ -287,15 +293,25 @@ void KNearestSmoothCompute::bucketCompare(TreePiece *ownerTP,
 
 /**
  * Process particles received from missed Cache request
+ * When allocPart/allocExtra are non-NULL, they are deferred-freed after walkDone.
  */
 void KNearestSmoothCompute::recvdParticlesFull(GravityParticle *part,
 				   int num, int chunk,int reqID, State *state,
-				   TreePiece *tp, Tree::NodeKey &remoteBucket){
+				   TreePiece *tp, Tree::NodeKey &remoteBucket,
+				   GravityParticle *allocPart, extraSPHData *allocExtra){
 
   Vector3D<cosmoType> offset = tp->decodeOffset(reqID);
   int reqIDlist = decodeReqID(reqID);
   CkAssert(num > 0);
   state->counterArrays[0][reqIDlist] -= num;
+
+  if (allocPart && allocExtra) {
+    NearNeighborState *nstate = (NearNeighborState *)state;
+    RecvdSmoothPartAlloc a;
+    a.part = allocPart;
+    a.extra = allocExtra;
+    nstate->pendingFrees[reqIDlist].push_back(a);
+  }
 
   GenericTreeNode* reqnode = tp->bucketList[reqIDlist];
 
@@ -668,6 +684,13 @@ void NearNeighborState::finishBucketSmooth(int iBucket, TreePiece *tp) {
 
   if(counterArrays[0][iBucket] == 0) {
     tp->sSmooth->walkDone(this);
+    if (pendingFrees && iBucket < nPendingFreesBuckets) {
+      for (int j = 0; j < pendingFrees[iBucket].length(); j++) {
+	delete[] pendingFrees[iBucket][j].part;
+	delete[] pendingFrees[iBucket][j].extra;
+      }
+      pendingFrees[iBucket].clear();
+    }
     if(verbosity>4)
 	CkPrintf("[%d] TreePiece %d finished smooth with bucket %d\n",CkMyPe(),
 		 tp->thisIndex,iBucket);
@@ -780,11 +803,17 @@ void KNearestSmoothCompute::walkDone(State *state) {
 /// @brief Allocate ReNearNeighborState
 ///
 /// called after constructor, so tp should be set
+void ReNearNeighborState::initPendingFrees(int nBuckets) {
+  nPendingFreesBuckets = nBuckets;
+  pendingFrees = new CkVec<RecvdSmoothPartAlloc>[nBuckets];
+}
+
 State *ReSmoothCompute::getNewState(int nBucket){
   ReNearNeighborState *state = new ReNearNeighborState(tp->myNumParticles+2);
   // array to keep track of outstanding requests
   state->counterArrays[0] = new int [nBucket];
   state->counterArrays[1] = 0;
+  state->initPendingFrees(nBucket);
   for (int j = 0; j < nBucket; ++j) {
     state->counterArrays[0][j] = 1;	// so we know that the local
 					// walk is not finished.
@@ -869,12 +898,21 @@ void ReSmoothCompute::bucketCompare(TreePiece *ownerTP,
  */
 void ReSmoothCompute::recvdParticlesFull(GravityParticle *part,
 				   int num, int chunk,int reqID, State *state,
-				   TreePiece *tp, Tree::NodeKey &remoteBucket){
+				   TreePiece *tp, Tree::NodeKey &remoteBucket,
+				   GravityParticle *allocPart, extraSPHData *allocExtra){
 
   Vector3D<cosmoType> offset = tp->decodeOffset(reqID);
   int reqIDlist = decodeReqID(reqID);
   CkAssert(num > 0);
   state->counterArrays[0][reqIDlist] -= num;
+
+  if (allocPart && allocExtra) {
+    ReNearNeighborState *nstate = (ReNearNeighborState *)state;
+    RecvdSmoothPartAlloc a;
+    a.part = allocPart;
+    a.extra = allocExtra;
+    nstate->pendingFrees[reqIDlist].push_back(a);
+  }
 
   GenericTreeNode* reqnode = tp->bucketList[reqIDlist];
 
@@ -992,6 +1030,13 @@ void ReNearNeighborState::finishBucketSmooth(int iBucket, TreePiece *tp) {
 
   if(counterArrays[0][iBucket] == 0) {
       tp->sSmooth->walkDone(this);
+    if (pendingFrees && iBucket < nPendingFreesBuckets) {
+      for (int j = 0; j < pendingFrees[iBucket].length(); j++) {
+	delete[] pendingFrees[iBucket][j].part;
+	delete[] pendingFrees[iBucket][j].extra;
+      }
+      pendingFrees[iBucket].clear();
+    }
     nParticlesPending -= node->particleCount;
   if(verbosity>4)
 	CkPrintf("[%d] TreePiece %d finished resmooth with bucket %d, %d Pending\n",CkMyPe(),
@@ -1032,10 +1077,16 @@ void ReSmoothCompute::walkDone(State *state) {
 }
 
 // called after constructor, so tp should be set
+void MarkNeighborState::initPendingFrees(int nBuckets) {
+  nPendingFreesBuckets = nBuckets;
+  pendingFrees = new CkVec<RecvdSmoothPartAlloc>[nBuckets];
+}
+
 State *MarkSmoothCompute::getNewState(int nBucket){
   MarkNeighborState *state = new MarkNeighborState(tp->myNumParticles+2);
   state->counterArrays[0] = new int [nBucket];
   state->counterArrays[1] = 0;
+  state->initPendingFrees(nBucket);
   for (int j = 0; j < nBucket; ++j) {
     state->counterArrays[0][j] = 1;	// so we know that the local
 					// walk is not finished.
@@ -1102,12 +1153,21 @@ void MarkSmoothCompute::bucketCompare(TreePiece *ownerTP,
  */
 void MarkSmoothCompute::recvdParticlesFull(GravityParticle *part,
 				   int num, int chunk,int reqID, State *state,
-				   TreePiece *tp, Tree::NodeKey &remoteBucket){
+				   TreePiece *tp, Tree::NodeKey &remoteBucket,
+				   GravityParticle *allocPart, extraSPHData *allocExtra){
 
   Vector3D<cosmoType> offset = tp->decodeOffset(reqID);
   int reqIDlist = decodeReqID(reqID);
   CkAssert(num > 0);
   state->counterArrays[0][reqIDlist] -= num;
+
+  if (allocPart && allocExtra) {
+    MarkNeighborState *nstate = (MarkNeighborState *)state;
+    RecvdSmoothPartAlloc a;
+    a.part = allocPart;
+    a.extra = allocExtra;
+    nstate->pendingFrees[reqIDlist].push_back(a);
+  }
 
   GenericTreeNode* reqnode = tp->bucketList[reqIDlist];
 
@@ -1205,6 +1265,13 @@ void MarkNeighborState::finishBucketSmooth(int iBucket, TreePiece *tp) {
 
   if(counterArrays[0][iBucket] == 0) {
       tp->sSmooth->walkDone(this);
+    if (pendingFrees && iBucket < nPendingFreesBuckets) {
+      for (int j = 0; j < pendingFrees[iBucket].length(); j++) {
+	delete[] pendingFrees[iBucket][j].part;
+	delete[] pendingFrees[iBucket][j].extra;
+      }
+      pendingFrees[iBucket].clear();
+    }
   if(verbosity>4)
 	CkPrintf("[%d] TreePiece %d finished smooth with bucket %d\n",CkMyPe(),
 		 tp->thisIndex,iBucket);

--- a/smooth.h
+++ b/smooth.h
@@ -22,6 +22,12 @@ class pqSmoothNode
     };
 
 	
+/// Allocation to free after walkDone (defer until bucket is done).
+struct RecvdSmoothPartAlloc {
+    GravityParticle *part;
+    extraSPHData *extra;
+};
+
 /// Object to bookkeep a Bucket Smooth Walk.
 
 class NearNeighborState: public State {
@@ -30,15 +36,29 @@ public:
     int nParticlesPending;
     int mynParts; 
     bool started;
-    
+    /// Per-bucket allocations from remote cache; freed after walkDone.
+    CkVec<RecvdSmoothPartAlloc> *pendingFrees;
+    int nPendingFreesBuckets;
+
     NearNeighborState(int nParts, int nSmooth) {
         Qs = new CkVec<pqSmoothNode>[nParts+2];
-	mynParts = nParts; 
+	mynParts = nParts;
+	pendingFrees = NULL;
+	nPendingFreesBuckets = 0;
         }
 
     void finishBucketSmooth(int iBucket, TreePiece *tp);
+    void initPendingFrees(int nBuckets);
     ~NearNeighborState() {
-	delete [] Qs; 
+	delete [] Qs;
+	if (pendingFrees) {
+	    for (int i = 0; i < nPendingFreesBuckets; i++)
+		for (int j = 0; j < pendingFrees[i].length(); j++) {
+		    delete[] pendingFrees[i][j].part;
+		    delete[] pendingFrees[i][j].extra;
+		}
+	    delete[] pendingFrees;
+	}
         }
 };
 
@@ -154,7 +174,8 @@ public:
     void nodeRecvdEvent(TreePiece *owner, int chunk, State *state, int bucket);
     void recvdParticlesFull(GravityParticle *egp,int num,int chunk,
 			int reqID,State *state, TreePiece *tp,
-			Tree::NodeKey &remoteBucket);
+			Tree::NodeKey &remoteBucket,
+			GravityParticle *allocPart=0, extraSPHData *allocExtra=0);
     void walkDone(State *state) ;
 
     // this function is used to allocate and initialize a new state object
@@ -175,11 +196,26 @@ public:
     CkVec<pqSmoothNode> *Qs;
     int nParticlesPending;
     bool started;
+    CkVec<RecvdSmoothPartAlloc> *pendingFrees;
+    int nPendingFreesBuckets;
     ReNearNeighborState(int nParts) {
 	Qs = new CkVec<pqSmoothNode>[nParts+2];
+	pendingFrees = NULL;
+	nPendingFreesBuckets = 0;
 	}
     void finishBucketSmooth(int iBucket, TreePiece *tp);
-    ~ReNearNeighborState() { delete [] Qs; }
+    void initPendingFrees(int nBuckets);
+    ~ReNearNeighborState() {
+	delete [] Qs;
+	if (pendingFrees) {
+	    for (int i = 0; i < nPendingFreesBuckets; i++)
+		for (int j = 0; j < pendingFrees[i].length(); j++) {
+		    delete[] pendingFrees[i][j].part;
+		    delete[] pendingFrees[i][j].extra;
+		}
+	    delete[] pendingFrees;
+	}
+    }
 };
 
 /// @brief Class for computation over a set smoothing length
@@ -207,7 +243,8 @@ public:
     void nodeRecvdEvent(TreePiece *owner, int chunk, State *state, int bucket);
     void recvdParticlesFull(GravityParticle *egp,int num,int chunk,
 			int reqID,State *state, TreePiece *tp,
-			Tree::NodeKey &remoteBucket);
+			Tree::NodeKey &remoteBucket,
+			GravityParticle *allocPart=0, extraSPHData *allocExtra=0);
     void walkDone(State *state) ;
 
     // this function is used to allocate and initialize a new state object
@@ -245,7 +282,8 @@ public:
     void nodeRecvdEvent(TreePiece *owner, int chunk, State *state, int bucket);
     void recvdParticlesFull(GravityParticle *egp,int num,int chunk,
 			int reqID,State *state, TreePiece *tp,
-			Tree::NodeKey &remoteBucket);
+			Tree::NodeKey &remoteBucket,
+			GravityParticle *allocPart=0, extraSPHData *allocExtra=0);
     void walkDone(State *state) ;
 
     // this function is used to allocate and initialize a new state object
@@ -262,9 +300,21 @@ class MarkNeighborState: public State {
 public:
     int nParticlesPending;
     bool started;
-    MarkNeighborState(int nParts) {}
+    CkVec<RecvdSmoothPartAlloc> *pendingFrees;
+    int nPendingFreesBuckets;
+    MarkNeighborState(int nParts) : pendingFrees(NULL), nPendingFreesBuckets(0) {}
     void finishBucketSmooth(int iBucket, TreePiece *tp);
-    ~MarkNeighborState() {}
+    void initPendingFrees(int nBuckets);
+    ~MarkNeighborState() {
+	if (pendingFrees) {
+	    for (int i = 0; i < nPendingFreesBuckets; i++)
+		for (int j = 0; j < pendingFrees[i].length(); j++) {
+		    delete[] pendingFrees[i][j].part;
+		    delete[] pendingFrees[i][j].extra;
+		}
+	    delete[] pendingFrees;
+	}
+    }
 };
 
 #include "Opt.h"


### PR DESCRIPTION
Always serialize cache data; never pass raw pointers across PEs. Defer free until after walkDone via pendingFrees.