### PR TITLE
Fix PEList launch readiness when local transfer lags remote transfer

### DIFF
--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -704,6 +704,17 @@ void DataManager::startLocalWalk() {
     delete localTransferCallback;
     bLocalDataTransferred.store(true);
 
+    // Delayed local kernels can now launch (remote may have completed first).
+    int pe;
+    int firstPE = CkNodeFirst(CkMyNode());
+    int nPEs = CkNodeSize(CkMyNode());
+    for (int i = 0; i < numPEListProxies; i++) {
+        for (int j = 0; j < nPEs; j++) {
+            pe = firstPE + j;
+            (*(PEListProxies[i]))[pe].tryLaunchDelayedKernel();
+        }
+    }
+
     // We arent calculating local gravity on the CPU, but bookkeeping
     // still needs to be handled
     for(int i = 0; i < registeredTreePieces.length(); i++){

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -518,8 +518,10 @@ void DataManager::startEwaldGPU() {
   // to avoid deadlock: TPs are waiting for their buckets to be marked finished.
   if (savedNumTotalParticles <= 0 || d_localParts == nullptr || d_localVars == nullptr) {
     for (int i = 0; i < registeredTreePieces.length(); i++) {
-      int in = registeredTreePieces[i].treePiece->getIndex();
-      treePieces[in].cudaFinishAllBuckets(1);
+        if(registeredTreePieces[i].treePiece->getNumActiveParticles() > 0) {
+            int in = registeredTreePieces[i].treePiece->getIndex();
+            treePieces[in].cudaFinishAllBuckets(1);
+        }
     }
     return;
   }
@@ -654,8 +656,10 @@ void DataManager::finishEwaldGPU() {
 #endif
 
   for(int i = 0; i < registeredTreePieces.length(); i++){
-      int in = registeredTreePieces[i].treePiece->getIndex();
-      treePieces[in].cudaFinishAllBuckets(1);
+      if(registeredTreePieces[i].treePiece->getNumActiveParticles() > 0) {
+          int in = registeredTreePieces[i].treePiece->getIndex();
+          treePieces[in].cudaFinishAllBuckets(1);
+      }
   }
 }
 
@@ -681,8 +685,10 @@ void DataManager::finishLocalWalk() {
 #endif
 
   for(int i = 0; i < registeredTreePieces.length(); i++){
-    int in = registeredTreePieces[i].treePiece->getIndex();
-    treePieces[in].cudaFinishAllBuckets(0);
+      if(registeredTreePieces[i].treePiece->getNumActiveParticles() > 0) {
+          int in = registeredTreePieces[i].treePiece->getIndex();
+          treePieces[in].cudaFinishAllBuckets(0);
+      }
   }
 #endif
 
@@ -701,8 +707,11 @@ void DataManager::startLocalWalk() {
     // We arent calculating local gravity on the CPU, but bookkeeping
     // still needs to be handled
     for(int i = 0; i < registeredTreePieces.length(); i++){
-      int in = registeredTreePieces[i].treePiece->getIndex();
-      treePieces[in].commenceCalculateGravityLocal();
+        /// Pieces with no active particles have been short-cut.
+        if(registeredTreePieces[i].treePiece->getNumActiveParticles() > 0) {
+            int in = registeredTreePieces[i].treePiece->getIndex();
+            treePieces[in].commenceCalculateGravityLocal();
+        }
     }
 
 #ifdef GPU_LOCAL_TREE_WALK
@@ -793,12 +802,15 @@ void DataManager::donePrefetch(int chunk){
 
   // Commence the remote walk
   for(int i = 0; i < registeredTreePieces.length(); i++){
-      if(verbosity > 1) CkPrintf("[%d] resumeRemoteChunk %d\n", CkMyPe(), i);
-      int in = registeredTreePieces[i].treePiece->getIndex();
+      if(verbosity > 1) CkPrintf("[%d] continueStartRemoteChunk %d\n", CkMyNode(), i);
+      if(registeredTreePieces[i].treePiece->getNumActiveParticles() > 0) {
+          int in = registeredTreePieces[i].treePiece->getIndex();
 #if COSMO_PRINT_BK > 1
-      CkPrintf("(%d) dm->%d\n", CkMyPe(), in);
+          CkPrintf("(%d) dm->%d\n", CkMyNode(), in);
 #endif
-      treePieces[in].continueStartRemoteChunk(0);
+          treePieces[in].continueStartRemoteChunk(0); // 0 is the chunk number;
+                                                      // assuming only one remote chunk
+      }
     }
 
     PendingBuffers *buffers = currentChunkBuffers;
@@ -1242,7 +1254,7 @@ void DataManager::transferParticleVarsBack(){
     data->buf = buf;
     data->size = savedNumTotalParticles;
 
-    if(verbosity > 1) CkPrintf("[%d] transferParticleVarsBack\n", CkMyPe());
+    if(verbosity > 1) CkPrintf("[%d] transferParticleVarsBack\n", CkMyNode());
     TransferParticleVarsBack(buf, 
                              savedNumTotalParticles*sizeof(VariablePartData),
 			     d_localVars,
@@ -1256,7 +1268,7 @@ void DataManager::updateParticles(UpdateParticlesStruct *data){
   int partIndex = 0;
 
 #ifdef CUDA_PRINT_TRANSFER_BACK_PARTICLES
-  CkPrintf("(%d) In DM::updateParticles %d tps\n", CkMyPe(), registeredTreePieces.length());
+  CkPrintf("(%d) In DM::updateParticles %d tps\n", CkMyNode(), (int) registeredTreePieces.length());
 #endif
 
   for(int i = 0; i < registeredTreePieces.length(); i++){

--- a/PEList.cpp
+++ b/PEList.cpp
@@ -1,6 +1,7 @@
 #ifdef CUDA
 
 #include "PEList.h"
+#include "DataManager.h"
 #include "HostCUDA.h"
 
 /// @brief Each TreePiece on a given PE checks in as its tree walk completes
@@ -27,21 +28,30 @@ void PEList::finishWalk(TreePiece *treePiece) {
     finishCb = new CkCallback(CkIndex_PEList::finishWalkCb(), CkMyPe(), thisProxy);
 
     // If the DataManager device pointer is NULL, the GPU data transfer is
-    // still in progress and we need to delay the kernel launch
-    bool dataReady = (!bRemote &&
-        dMProxy.ckLocalBranch()->bLocalDataTransferred.load()) ||
-        (bRemote && dMProxy.ckLocalBranch()->bRemoteDataTransferred.load());
+    // still in progress and we need to delay the kernel launch.
+    // launchKernel() always uses d_localMoments/d_localParts; remote also needs remote data.
+    DataManager *dm = dMProxy.ckLocalBranch();
+    bool dataReady = dm->bLocalDataTransferred.load() &&
+        (!bRemote || dm->bRemoteDataTransferred.load());
     if (!dataReady)
         bKernelDelayed = 1;
     else
         launchKernel();
 }
 
-/// @brief Called from DataManager after remote transfer finishes. Launch our kernel if it was delayed
+/// @brief Called from DataManager when remote or local transfer finishes.
+/// Launch our kernel only if it was delayed AND the data we need is now ready.
+/// launchKernel() always uses d_localMoments/d_localParts; remote also needs remote data.
 void PEList::tryLaunchDelayedKernel() {
-    if (bKernelDelayed) {
-        launchKernel();
-    }
+    if (!bKernelDelayed)
+        return;
+    DataManager *dm = dMProxy.ckLocalBranch();
+    bool dataReady = dm->bLocalDataTransferred.load() &&
+        (!bRemote || dm->bRemoteDataTransferred.load());
+    if (!dataReady)
+        return;
+    bKernelDelayed = 0;
+    launchKernel();
 }
 
 void PEList::finishWalkCb() {

--- a/PEList.cpp
+++ b/PEList.cpp
@@ -54,10 +54,11 @@ void PEList::launchKernel() {
     CkAssert(dMProxy.ckLocalBranch()->d_localMoments != nullptr);
     CkAssert(dMProxy.ckLocalBranch()->d_localParts != nullptr);
     CkAssert(dMProxy.ckLocalBranch()->d_localVars != nullptr);
-    if (bRemote) {
-        CkAssert(dMProxy.ckLocalBranch()->d_remoteParts != nullptr);
-        CkAssert(dMProxy.ckLocalBranch()->d_remoteMoments != nullptr);
-    }
+    // The following checks can fail if remote prefetch does not bring in any data.
+    // if (bRemote) {
+    //    CkAssert(dMProxy.ckLocalBranch()->d_remoteParts != nullptr);
+    //    CkAssert(dMProxy.ckLocalBranch()->d_remoteMoments != nullptr);
+    // }
 
     request->d_localMoments = dMProxy.ckLocalBranch()->d_localMoments;
     request->d_localParts = dMProxy.ckLocalBranch()->d_localParts;

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -906,6 +906,14 @@ class TreePiece : public CBase_TreePiece {
   /// Return the pointer to the particles on this TreePiece.
   GravityParticle *getParticles(){return myParticles;}
 
+    /// Number of particles on this TreePiece needing force calculations
+    int myNumActiveParticles;
+
+    /// Access method for number of active particles on this TreePiece
+    int getNumActiveParticles(){
+        return myNumActiveParticles;
+    }
+
 
 #ifdef CUDA
         // this variable holds the number of buckets active at
@@ -918,7 +926,6 @@ class TreePiece : public CBase_TreePiece {
         // in the list of interations to the sent to the gpu, we flush
         // the list
         int numActiveBuckets; 
-        int myNumActiveParticles;
         // First and Last indices of GPU particle
         int FirstGPUParticleIndex;
         int LastGPUParticleIndex;
@@ -948,19 +955,6 @@ class TreePiece : public CBase_TreePiece {
         // total count.
         int getDMNumParticles(){
           return myNumParticles;
-        }
-
-        int getNumActiveParticles(){
-          return myNumActiveParticles;
-        }
-
-        void calculateNumActiveParticles(){ 
-          myNumActiveParticles = 0;
-          for(int i = 1; i <= myNumParticles; i++){
-            if(myParticles[i].rung >= activeRung){
-              myNumActiveParticles++;
-            }
-          }
         }
 
         void getDMParticles(CompactPartData *fillArray, int &fillIndex){
@@ -1375,8 +1369,7 @@ private:
 
 
 	/// Initialize all the buckets for the tree walk
-	/// @TODO: Eliminate this redundant copy!
-	void initBuckets();
+	int initBuckets();
 	template <class Tsmooth>
 	void initBucketsSmooth(Tsmooth tSmooth);
 	void smoothNextBucket();

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3659,9 +3659,11 @@ int reEncodeOffset(int reqID, int offsetID)
 /**
  * Initialize all particles for gravity force calculation.
  * This includes zeroing out the acceleration and potential.
+ * @returns Number of active particles on this TreePiece.
  */
-void TreePiece::initBuckets() {
+int TreePiece::initBuckets() {
   int ewaldCondition = (bEwald ? 0 : 1);
+  int nActive = 0;
   for (unsigned int j=0; j<numBuckets; ++j) {
     GenericTreeNode* node = bucketList[j];
 
@@ -3671,6 +3673,7 @@ void TreePiece::initBuckets() {
 				// Active bounds
     for(int i = node->firstParticle; i <= node->lastParticle; ++i) {
       if (myParticles[i].rung >= activeRung) {
+        nActive++;
         myParticles[i].treeAcceleration = 0;
         myParticles[i].potential = 0;
 	myParticles[i].dtGrav = 0;
@@ -3701,6 +3704,7 @@ void TreePiece::initBuckets() {
 #if COSMO_DEBUG > 1 || defined CHANGA_REFACTOR_WALKCHECK || defined CHANGA_REFACTOR_WALKCHECK_INTERLIST
   bucketcheckList.resize(numBuckets);
 #endif
+  return nActive;
 }
 
 void TreePiece::startNextBucket() {
@@ -3803,7 +3807,7 @@ void TreePiece::finishBucket(int iBucket) {
 
   CkAssert(remaining >= 0);
 #ifdef COSMO_PRINT
-  CkPrintf("[%d] Is finished %d? finished=%d, %d still missing!\n",thisIndex,iBucket,req->finished, remaining);
+  CkPrintf("[%d] Is finished %d? finished=%d, %d still missing; remote %d local %d!\n",thisIndex,iBucket,req->finished, remaining, sRemoteGravityState->counterArrays[0][iBucket], sLocalGravityState->counterArrays[0][iBucket]);
 #endif
 
   // XXX finished means Ewald is done.
@@ -5056,19 +5060,16 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
       cacheGravPart.ckLocalBranch()->finishedChunk(i, 0);
     }
     nodeLBMgrProxy.ckLocalBranch()->finishedTPWork();
-    if (bUseCpu) {
-      CkCallback cbf = CkCallback(CkIndex_TreePiece::finishWalk(), pieces);
-      gravityProxy[thisIndex].ckLocal()->contribute(cbf);
-    }
 #ifdef CUDA
-    else {
+    if (!bUseCpu) {
       // Every PE must call TransferParticleVarsBack, even if no particle data
       for (int i = 0; i < numPEListProxies; i++) {
         PEListProxies[i]->ckLocalBranch()->finishWalk(this);
       }
-      gravityProxy[thisIndex].ckLocal()->contribute();
     }
 #endif
+    CkCallback cbf = CkCallback(CkIndex_TreePiece::finishWalk(), pieces);
+    gravityProxy[thisIndex].ckLocal()->contribute(cbf);
     bBucketsInited = true;
     return;
   }
@@ -5097,8 +5098,35 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
   traceUserBracketEvent(START_REG, starttime, CmiWallTimer());
 
   starttime = CmiWallTimer();
-  initBuckets();
+  myNumActiveParticles = initBuckets();
   traceUserBracketEvent(START_IB, starttime, CmiWallTimer());
+  if(getNumActiveParticles() == 0) {
+      // No active particles on this TreePiece; Short-circuit the tree
+      // walk.  This is similar to the code above for no particles on
+      // the TreePiece.
+      for (int i=0; i< numChunks; ++i) {
+          cacheGravPart.ckLocalBranch()->finishedChunk(i, 0);
+      }
+      nodeLBMgrProxy.ckLocalBranch()->finishedTPWork();
+#ifdef CUDA
+      if (!bUseCpu) {
+          // This trees particles and nodes still need to be loaded
+          // onto the GPU
+          dm->serializeLocalTree();
+          // Let DM know we have "completed" the prefetch as well
+          dm->donePrefetch(0);  // 0 is the chunk number; assuming
+                                // only one chunk
+          // Every PE must call TransferParticleVarsBack, even if no particle data
+          for (int i = 0; i < numPEListProxies; i++) {
+              PEListProxies[i]->ckLocalBranch()->finishWalk(this);
+              }
+      }
+#endif
+      CkCallback cbf = CkCallback(CkIndex_TreePiece::finishWalk(), pieces);
+      gravityProxy[thisIndex].ckLocal()->contribute(cbf);
+      bBucketsInited = true;
+      return;
+  }
 
   starttime = CmiWallTimer();
   prefetchReq.reset();
@@ -5178,7 +5206,6 @@ void TreePiece::startGravity(int am, // the active mask for multistepping
 #ifdef CUDA
 
   numActiveBuckets = 0;
-  calculateNumActiveParticles();
 
   if (!bUseCpu) {
 


### PR DESCRIPTION
## Base branch

**This PR is intended to be opened with base branch: `trq/inactive_treepiece`** (upstream PR #18).

---

## Problem

In CosmoRun on top of PR #18 (`trq/inactive_treepiece`), gravity step 1 could hit a PEList assertion: `d_localMoments != nullptr` (or equivalent) in `PEList::launchKernel`. That happened when many inactive TreePieces existed after load balancing: local GPU data transfer (all TreePieces on the node calling `fillGPUBuffer` → `transferLocalToGPU` → `startLocalWalk`) could finish later than remote transfer. Remote PELists were allowed to launch as soon as `bRemoteDataTransferred` was true, without requiring `bLocalDataTransferred`. Because `launchKernel()` always uses `d_localMoments` and `d_localParts`, every launch must wait for local data to be transferred; remote PELists must also have remote data. Allowing launch when only remote was ready could run the kernel before local data was on the GPU.

## Root cause

- Readiness in `PEList::finishWalk` was "local ready OR remote ready" (local PELists required only local; remote PELists only remote). So remote PELists could be considered ready and launch before local transfer completed.
- `tryLaunchDelayedKernel()` was only invoked from `DataManager::resumeRemoteChunk` (when remote transfer completed). It did not re-check readiness and did not run when local transfer completed first, so delayed local kernels had no path to launch when only local was done.

## Fix

1. **PEList::finishWalk**  
   Require `bLocalDataTransferred` for every PEList launch, and for remote PELists also require `bRemoteDataTransferred`:  
   `dataReady = bLocalDataTransferred && (!bRemote || bRemoteDataTransferred)`.

2. **PEList::tryLaunchDelayedKernel**  
   Re-check the same readiness before launching. If not ready, return (stay delayed). If ready, clear `bKernelDelayed` and call `launchKernel()`.

3. **DataManager::startLocalWalk**  
   After setting `bLocalDataTransferred`, call `tryLaunchDelayedKernel()` for all PEList instances on the node so delayed local kernels can launch when local transfer completes (e.g. when remote had already completed and had triggered a delayed state).

Delayed-launch behavior is preserved; retry is triggered from both remote transfer completion (`resumeRemoteChunk`) and local transfer completion (`startLocalWalk`).

## Verification

- PEList assertion is gone.
- Gravity/SPH step completes in CosmoRun with the fix applied on top of `trq/inactive_treepiece`.

## Note on later failures

A later NaN/binbox failure in CosmoRun is **separate and out of scope** for this PR. This change addresses only the PEList/DataManager readiness bug.