### PR TITLE
TreePiece constructors: initialize nEwhLoop.

### DIFF
--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1487,7 +1487,7 @@ public:
 	  prefetchRoots = NULL;
           ewt = NULL;
           nEwhLoop = 0;
-	  nMaxEwhLoop = 100;
+          nMaxEwhLoop = 100;
 	  root = NULL;
 	  pTreeNodes = NULL;
 

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1445,6 +1445,7 @@ public:
 	  numChunks=-1;
 	  prefetchRoots = NULL;
 	  ewt = NULL;
+          nEwhLoop = 0;
 	  nMaxEwhLoop = 100;
 
           incomingParticlesMsg.clear();
@@ -1484,8 +1485,9 @@ public:
 	  nPartCacheEntries = 0;
 	  completedActiveWalks = 0;
 	  prefetchRoots = NULL;
-	  //remaining Chunk = NULL;
           ewt = NULL;
+          nEwhLoop = 0;
+	  nMaxEwhLoop = 100;
 	  root = NULL;
 	  pTreeNodes = NULL;
 


### PR DESCRIPTION
nEwhLoop is checked for a valid value in DataManager before loading the Ewald h table onto the GPU.  It needs to be set to an invalid value before the h-table is constructed.